### PR TITLE
return floor plan if requested

### DIFF
--- a/src/modal_functions/unav.py
+++ b/src/modal_functions/unav.py
@@ -41,6 +41,7 @@ class UnavServer:
         floor: str = "",
         place: str = "",
         base_64_image: str = None,
+        get_floor_plan: bool = False,
     ):
 
         import json
@@ -102,6 +103,10 @@ class UnavServer:
         )  # Print total elapsed time
 
         scale = self.server.config["location"]["scale"]
+
+        if(get_floor_plan):
+            floorplan_base64 = pose["floorplan_base64"]
+            return json.dumps({"trajectory": trajectory, "scale": scale, "floorplan_base64" : floorplan_base64}) #return floor plan if requested 
 
         return json.dumps({"trajectory": trajectory, "scale": scale})
 


### PR DESCRIPTION
Added a case return floor plan (base_64) in response if requested ,

considering the response of pose after localising is as follows Pose:  {'building': 'LightHouse', 'floor': '6_floor', 'pose': [3887.608730672621, 1760.2426575864347, 307.48769890019616], 'floorplan_base64': " " }

@surendhar-palanisamy can you please review 