### PR TITLE
Fix duplitcate lines and add missing comma

### DIFF
--- a/src/UNav_core/src/navigation/trajectory.py
+++ b/src/UNav_core/src/navigation/trajectory.py
@@ -340,7 +340,7 @@ class Trajectory():
                 'floor': current_floor,
                 'paths': [[current_pose[0], current_pose[1]]] + following_paths,
                 'command': command_instruction,
-                'scale': scale
+                'scale': scale,
                 'paths': [[current_pose[0], current_pose[1]]] + following_paths,
                 'command': command_instruction,
                 'scale': scale

--- a/src/UNav_core/src/track/hierarchical_localization.py
+++ b/src/UNav_core/src/track/hierarchical_localization.py
@@ -32,7 +32,6 @@ def read_pickle_file(file_path):
 
 class Coarse_Locator:
     def __init__(self, feature, config):
-    def __init__(self, feature, config):
         """
         Initializes the VPR class.
         :param root: Path to the directory containing the combined global_features.h5 file.


### PR DESCRIPTION
This pull request includes minor fixes to the `calculate_path` method in `trajectory.py` and a minor formatting change in the `Coarse_Locator` class in `hierarchical_localization.py`.

* [`src/UNav_core/src/navigation/trajectory.py`](diffhunk://#diff-be68e47fcacb53aca5077368fe75bfac6d31a46a03331b739e1f7eff7bc01474L343-R343): Fixed a duplicate 'paths' key in the dictionary within the `calculate_path` method.
* [`src/UNav_core/src/track/hierarchical_localization.py`](diffhunk://#diff-0d07d9a691846544422e7a374e30bdd2a5510e332b9b568e18d91cafb17e6813L34): Corrected indentation in the `__init__` method of the `Coarse_Locator` class.