### PR TITLE
AR grounding: thread per-floor scale into trajectory response

### DIFF
--- a/src/modal_functions/unav_v2/logic/navigation.py
+++ b/src/modal_functions/unav_v2/logic/navigation.py
@@ -357,7 +357,12 @@ def run_planner(
                     f"top_candidates_count={len(result.get('top_candidates') or [])}"
                 )
 
-                return run_convert_navigation_to_trajectory(result)
+                # Per-floor meters-per-pixel from scale.json (keyed by the raw
+                # tuple — serialized_source_key is a list and would not match).
+                floor_scale = getattr(self.nav, "scales", {}).get(
+                    (start_place, start_building, start_floor)
+                )
+                return run_convert_navigation_to_trajectory(result, scale=floor_scale)
 
             except Exception as e:
                 timing_data["total"] = (time.time() - start_time) * 1000

--- a/src/modal_functions/unav_v2/logic/utils.py
+++ b/src/modal_functions/unav_v2/logic/utils.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 
 def run_safe_serialize(obj: Any) -> Any:
@@ -44,11 +44,23 @@ def run_construct_mock_localization_output(
     }
 
 
+# Legacy constant (the LightHouse 3_floor scale) kept only as a last-resort
+# fallback so behavior is unchanged when no per-floor scale is available.
+_LEGACY_FALLBACK_SCALE = 0.02205862195
+
+
 def run_convert_navigation_to_trajectory(
-    navigation_result: Dict[str, Any]
+    navigation_result: Dict[str, Any],
+    scale: Optional[float] = None,
 ) -> Dict[str, Any]:
     """
     Convert navigation result format to trajectory output format.
+
+    Args:
+        navigation_result: Planner output dict.
+        scale: Per-floor meters-per-pixel value (from the navigator's
+            scale.json). Falls back to the legacy constant when missing
+            or invalid.
     """
     result = navigation_result.get("result", {})
     cmds = navigation_result.get("cmds", [])
@@ -62,11 +74,12 @@ def run_convert_navigation_to_trajectory(
     path_coords = result.get("path_coords", [])
 
     start_xy = floorplan_pose.get("xy", [])
-    start_ang = floorplan_pose.get("ang", 0)
+    start_ang = floorplan_pose.get("ang")
 
     paths = []
     if start_xy and len(start_xy) >= 2:
-        if start_ang:
+        # `is not None` so a legitimate 0-degree heading is not dropped.
+        if start_ang is not None:
             paths.append([start_xy[0], start_xy[1], start_ang])
         else:
             paths.append(start_xy)
@@ -75,7 +88,11 @@ def run_convert_navigation_to_trajectory(
         if len(coord) >= 2:
             paths.append(coord)
 
-    scale = 0.02205862195
+    # The navigator defaults floors missing from scale.json to 1.0, and
+    # historic scale.json files contain literal 0 placeholders; downstream
+    # clients treat scale == 1.0 as "unscaled", so reject both and fall back.
+    if not scale or scale <= 0 or scale == 1.0:
+        scale = _LEGACY_FALLBACK_SCALE
 
     trajectory_data = {
         "trajectory": [


### PR DESCRIPTION
## Summary

Part of a synchronized cross-repo fix (`fix/ar-grounding-deterministic`) for the AR navigation path rendering through walls / at wrong angles in unav-pro. Root cause addressed here: the trajectory converter hardcoded a single meters-per-pixel constant (`0.02205862195` — the LightHouse 3_floor scale) for **every** place/building/floor, so any floor with a different true scale produced proportionally wrong real-world distances, which the AR client uses to place the path (e.g. Langone 15_floor is ~10% off, LightHouse 6_floor ~2× off).

## Scope in this repo

- `logic/navigation.py`: look up the per-floor scale from the navigator's `scales` dict (keyed by the raw `(place, building, floor)` tuple) and pass it into the trajectory conversion.
- `logic/utils.py`: `run_convert_navigation_to_trajectory` accepts an optional `scale`; sanitizes it (rejects `None`, `<= 0`, and `1.0` — the navigator's missing-floor default and the historic placeholder values) and falls back to the legacy constant, so behavior is byte-identical when no per-floor scale exists.
- `logic/utils.py`: preserve a legitimate 0° start heading — the old truthiness check silently dropped `ang == 0.0` from the trajectory start point.

## Companion PRs

- API: https://github.com/rizzojr01/vis4ion-api-server/pull/437
- Frontend: https://github.com/rizzojr01/unav-pro/pull/1

## Merge/deploy order

Server (this PR) → API → frontend. Each layer's change is backward-compatible on its own: old clients ignore the corrected scale; new clients fall back safely when an old server sends the unscaled sentinel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
