### PR TITLE
Warm the localizer in the background after ensure-maps (P0 localization latency)

### DIFF
--- a/src/modal_functions/unav_v2/logic/maps.py
+++ b/src/modal_functions/unav_v2/logic/maps.py
@@ -2,6 +2,7 @@ from typing import Any, Dict, Optional, Set
 
 import os
 import functools
+import threading
 import time
 
 from .places import run_get_places
@@ -85,6 +86,12 @@ def run_ensure_maps_loaded(
         except Exception as e:
             print(f"⚠️ Failed to patch selective localizer: {e}")
 
+    # Synchronous part stays minimal: global features + transforms, which any
+    # localization needs for correctness. The caller (e.g. a destinations-list
+    # request) should NOT pay for COLMAP floor models / VPR index / model
+    # kernel warmup — that heavy work runs in the background thread below, so
+    # the first user localization finds the localizer already warm without any
+    # user-facing call having blocked on it.
     if hasattr(server, "tracer") and server.tracer:
         with server.tracer.start_as_current_span(
             "load_maps_and_features_span"
@@ -105,6 +112,23 @@ def run_ensure_maps_loaded(
         selective_localizer.load_maps_and_features()
         load_duration = time.time() - start_load_time
         print(f"⏱️ Completed load_maps_and_features in {load_duration:.2f} seconds")
+
+    if hasattr(selective_localizer, "warmup"):
+        def _background_warmup():
+            try:
+                t0 = time.time()
+                stages = selective_localizer.warmup()
+                detail = ", ".join(f"{k}={v:.2f}s" for k, v in stages.items())
+                print(f"🔥 Background localizer warmup done for {map_key} "
+                      f"in {time.time() - t0:.2f}s ({detail})", flush=True)
+            except Exception as e:
+                # Warmup is an optimization: on failure the localizer still
+                # works, it just lazy-loads on first query as before.
+                print(f"⚠️ Background localizer warmup failed for {map_key}: {e}",
+                      flush=True)
+
+        threading.Thread(target=_background_warmup, daemon=True,
+                         name=f"unav-warmup-{map_key}").start()
 
     server.selective_localizers[map_key] = selective_localizer
     server.maps_loaded.add(map_key)


### PR DESCRIPTION
## What

`run_ensure_maps_loaded` keeps its synchronous work minimal (`load_maps_and_features()` — global features + transforms, required for localization correctness) and moves the heavy one-time work — COLMAP floor models, VPR search index, model kernel warmup — to a **daemon background thread** via `UNavLocalizer.warmup()`.

## Why

Two problems, one change:

1. *"Consecutive localizations took close to or over 1 minute even after the server had been warmed by a destination-list call"* (P0): the ensure-maps step never touched COLMAP models or the VPR index, so the **first user localization** paid tens of seconds of lazy loading mid-request. Now warmup runs in the background right after ensure-maps, so the first localization finds everything already resident.
2. Per Suren's point: a destinations request shouldn't load all the features when the user just needs a list of destinations. The background design means **no user-facing call ever blocks on warmup** — the earlier revision of this PR ran warmup synchronously inside the destinations path, which got this wrong; fixed.

## Safety

- Warmup failure is non-fatal (logged; localizer falls back to lazy loading exactly as before).
- On an older `unav` package without `warmup()`, the thread is never spawned — behavior is byte-identical to current production. Merge order with the core PR doesn't matter.
- Warmup stage timings are printed on completion for the profiling record.

## Companion PRs

- Core: https://github.com/rizzojr01/unav/pull/1 (adds `warmup()` + per-stage profiling) and https://github.com/rizzojr01/unav/pull/2 (cold-start: parallel floor loading + parse caches — makes the background warmup itself ~5x faster on the data-load portion).

## Note on target branch

Currently based on `endeleze`; may need retargeting depending on which branch the Modal deploy is actually built from (`main` vs `integrate_backend_snap_to_route`) — pending Suren's confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)